### PR TITLE
fix: fixes right click context menu by adding a check for property runningActivities

### DIFF
--- a/contents/ui/code/tools.js
+++ b/contents/ui/code/tools.js
@@ -36,8 +36,8 @@ function createFavoriteActions(i18n, favoriteModel, favoriteId) {
     }
 
 
-    if (favoriteModel.activities === undefined ||
-        favoriteModel.activities.runningActivities.length <= 1) {
+    if (favoriteModel.activities === undefined || !favoriteModel.activities.hasOwnProperty("runningActivities")
+        || favoriteModel.activities.runningActivities.length <= 1) {
         var action = {};
 
         if (favoriteModel.isFavorite(favoriteId)) {


### PR DESCRIPTION
Hi, I'm maintaining a fork of dittomenu (by adhe). They share a lot of code between menus. While debugging the right-click context menu, I found a missing check that broke context menus. This PR fixes that same bug for this menu.